### PR TITLE
Update ehighway.yaml - eHighway cluster 88_SE is defined twice

### DIFF
--- a/definitions/region/ehighway.yaml
+++ b/definitions/region/ehighway.yaml
@@ -550,7 +550,7 @@
   - Sweden|Subgrid 89:
       country: Sweden
       definition: SE212 + SE221 + SE224 + SE231
-      ehighway2050: 88_SE
+      ehighway2050: 89_SE
       note: This region was defined and used in the ehighway2050 public datasets
   - United Kingdom|Subgrid 90:
       country: United Kingdom


### PR DESCRIPTION
I think I spotted a minor error in the definition of eHighway cluster 89_SE. eHighway cluster 88_SE has been defined twice. My adjustment changes the 88_SE to 89_SE on Line 553 of the file. 